### PR TITLE
test: add service unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsc -p tsconfig.test.json && node scripts/fix-imports.cjs && node --test dist/tests"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",

--- a/scripts/fix-imports.cjs
+++ b/scripts/fix-imports.cjs
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const dir = path.join(process.cwd(), 'dist', 'src', 'services');
+if (fs.existsSync(dir)) {
+  for (const file of fs.readdirSync(dir)) {
+    const filePath = path.join(dir, file);
+    let content = fs.readFileSync(filePath, 'utf8');
+    content = content.replace(/\.\/auth"/g, './auth.js"').replace(/\.\/user"/g, './user.js"');
+    fs.writeFileSync(filePath, content);
+  }
+}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { setToken, getToken, removeToken, isTokenExpired, isAuthenticated } from '../src/services/auth.js';
+import { LocalStorageMock, createToken } from './test-utils.js';
+
+beforeEach(() => {
+  // @ts-ignore
+  globalThis.localStorage = new LocalStorageMock();
+});
+
+describe('auth service', () => {
+  it('stores and retrieves a valid token', () => {
+    const token = createToken({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    setToken(token);
+    assert.strictEqual(getToken(), token);
+  });
+
+  it('does not store an invalid token', () => {
+    setToken('invalid-token');
+    assert.strictEqual(getToken(), null);
+  });
+
+  it('removes a stored token', () => {
+    const token = createToken({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    setToken(token);
+    removeToken();
+    assert.strictEqual(getToken(), null);
+  });
+
+  it('detects expired tokens', () => {
+    const expired = createToken({ exp: Math.floor(Date.now() / 1000) - 10 });
+    setToken(expired);
+    assert.strictEqual(isTokenExpired(), true);
+  });
+
+  it('checks authentication status', () => {
+    const token = createToken({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    setToken(token);
+    assert.strictEqual(isAuthenticated(), true);
+    removeToken();
+    assert.strictEqual(isAuthenticated(), false);
+  });
+});

--- a/tests/permisos.test.ts
+++ b/tests/permisos.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { tienePermiso } from '../src/services/permisos.js';
+import { LocalStorageMock, createToken } from './test-utils.js';
+
+beforeEach(() => {
+  // @ts-ignore
+  globalThis.localStorage = new LocalStorageMock();
+});
+
+describe('permisos service', () => {
+  it('returns true when user has permitted role', () => {
+    const payload = { id: 1, rol: '1', nombre: 'Admin', email: 'a@example.com', exp: Math.floor(Date.now() / 1000) + 3600 };
+    const token = createToken(payload);
+    localStorage.setItem('accessToken', token);
+    assert.strictEqual(tienePermiso(['Administrador']), true);
+  });
+
+  it('returns false when user lacks permitted role', () => {
+    const payload = { id: 1, rol: '2', nombre: 'Vend', email: 'v@example.com', exp: Math.floor(Date.now() / 1000) + 3600 };
+    const token = createToken(payload);
+    localStorage.setItem('accessToken', token);
+    assert.strictEqual(tienePermiso(['Administrador']), false);
+  });
+
+  it('returns false when no user token', () => {
+    assert.strictEqual(tienePermiso(['Administrador']), false);
+  });
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+
+export class LocalStorageMock {
+  private store: Record<string, string> = {};
+  clear() {
+    this.store = {};
+  }
+  getItem(key: string) {
+    return this.store[key] ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.store[key] = value;
+  }
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+}
+
+export function createToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getUsuario } from '../src/services/user.js';
+import { LocalStorageMock, createToken } from './test-utils.js';
+
+beforeEach(() => {
+  // @ts-ignore
+  globalThis.localStorage = new LocalStorageMock();
+});
+
+describe('user service', () => {
+  it('returns decoded user from token', () => {
+    const payload = { id: 1, rol: '1', nombre: 'Test', email: 't@example.com', exp: Math.floor(Date.now() / 1000) + 3600 };
+    const token = createToken(payload);
+    localStorage.setItem('accessToken', token);
+    assert.deepStrictEqual(getUsuario(), payload);
+  });
+
+  it('returns null for invalid token', () => {
+    localStorage.setItem('accessToken', 'invalid.token');
+    assert.strictEqual(getUsuario(), null);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/services/**/*.ts", "tests/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- add unit tests for auth, user, and permission services
- enable test command with minimal build step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951066d8a48323a0adb982b43d760b